### PR TITLE
Update Dutch language file and fix spelling error

### DIFF
--- a/languages/en.lua
+++ b/languages/en.lua
@@ -38,6 +38,6 @@ Languages["en"] = {
     depoitem3 = "You have deposited ",
     of        = " of ", 
     withitem = "You have withdrawn ",
-    cant = "You cant deposit this item",
+    cant = "You cannot deposit this item",
     closed = "The bank is currently closed"
 }

--- a/languages/nl.lua
+++ b/languages/nl.lua
@@ -35,8 +35,9 @@ Languages["nl"] = {
     success = "Je hebt het volgende betaald om jouw kluisruimte te vergroten: $ ",
     maxslots = "Je hebt het maximale aantal plaatsen bereikt: ",
     maxitems = "Het limiet voor dit voorwerp is: ",
-    depoitem3 = "Je hebt gestort: ",
-    of        = "x ", 
+    depoitem3 = "Je hebt opgeslagen: ",
+    of = "x ",
     withitem = "Je hebt opgenomen: ",
-    closed = "The bank is currently closed"
+    cant = "Je kunt dit voorwerp niet opslaan",
+    closed = "De bank is op dit moment gesloten"
 }


### PR DESCRIPTION
- Added translations for the 2 new translations "cant" and "closed" in the Dutch language file.
- Slightly improved the translation for "depoitem3" in Dutch language file.
- Fixed spelling error in translation for "cant" in English language file.
